### PR TITLE
Check for empty matrix when converting from SprsMat to scipy

### DIFF
--- a/stag/utility.py
+++ b/stag/utility.py
@@ -16,7 +16,12 @@ def swig_sprs_to_scipy(swig_mat):
     outer_starts = stag_internal.sprsMatOuterStarts(swig_mat)
     inner_indices = stag_internal.sprsMatInnerIndices(swig_mat)
     values = stag_internal.sprsMatValues(swig_mat)
-    return scipy.sparse.csc_matrix((values, inner_indices, outer_starts))
+
+    # If the last entry in outer_starts is 0, then this is the empty matrix.
+    if outer_starts[-1] == 0:
+        return scipy.sparse.csc_matrix((1, 1))
+    else:
+        return scipy.sparse.csc_matrix((values, inner_indices, outer_starts))
 
 
 def scipy_to_swig_sprs(scipy_mat: scipy.sparse.csc_matrix):

--- a/test/test_clustering.py
+++ b/test/test_clustering.py
@@ -89,6 +89,22 @@ def test_approximate_pagerank():
     np.testing.assert_almost_equal(r.todense().transpose().tolist()[0], expected_r)
 
 
+def test_approximate_pagerank_no_push():
+    # Test the behaviour of the approximate pagerank method when there is no push operation.
+    graph = 3 * stag.graph.cycle_graph(4)
+
+    # Construct seed matrix.
+    s = scipy.sparse.lil_matrix((4, 1))
+    s[0, 0] = 1
+
+    # Run the personalised pagerank and check that we get the right result
+    p, r = stag.cluster.approximate_pagerank(graph, s.tocsc(), 1./3, 1./2)
+    expected_p = [0]
+    expected_r = [1]
+    np.testing.assert_almost_equal(p.todense().transpose().tolist()[0], expected_p)
+    np.testing.assert_almost_equal(r.todense().transpose().tolist()[0], expected_r)
+
+
 def test_sweep_set():
     # Construct a simple graph to test with
     graph = stag.graph.barbell_graph(4)


### PR DESCRIPTION
Fixes #44 .