### PR TITLE
Add test for invalid adj mat

### DIFF
--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -10,6 +10,7 @@ from context import stag
 import stag.graph
 import stag.random
 import stag.graphio
+import stag.utility
 
 # Define the matrices of some useful graphs.
 C4_ADJ_MAT = scipy.sparse.csc_matrix([[0, 1, 0, 1],
@@ -535,3 +536,15 @@ def test_add_vertices():
                                              [0, 1.5, 0, 0, 0, 0]])
     mat_diff = g.adjacency().to_scipy() - expected_adj_mat
     assert (np.all(mat_diff.todense() == pytest.approx(0)))
+
+
+def test_initialise_with_negative_weights():
+    # See stagpy issue #43.
+    mat = stag.utility.SprsMat([[0, -1, 0, 1],
+                                [-1, 0, 1, 0],
+                                [0, 1, 0, 1],
+                                [1, 0, 1, 0]])
+
+    # Initialising a graph should throw an error
+    with pytest.raises(AttributeError):
+        _ = stag.graph.Graph(mat)


### PR DESCRIPTION
Fixes #43 .

Already fixed by stag issue 126. Added a test in stagpy.